### PR TITLE
endormorphic = TRUE, return MPRASet with results added to rowData

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -26,13 +26,14 @@ mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
 
     # what type of object to return
     if (endomorphic) {
-      attr(object, "MArrayLM") <- fit
-      tt <- topTable(fit, ..., number=nrow(fit), sort.by="none")
-      stopifnot(all.equal(rowData(object)$eid, rownames(tt)))
-      rowData(object) <- cbind(rowData(object), tt)
-      return(object)
+        attr(object, "MArrayLM") <- fit
+        tt <- topTable(fit, ..., number=nrow(fit), sort.by="none")
+        stopifnot(all(rownames(tt) %in% rowData(object)$eid))
+        tt <- tt[rowData(object)$eid, ]
+        rowData(object) <- cbind(rowData(object), tt)
+        return(object)
     } else {
-      return(fit)
+        return(fit)
     }
 }
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -26,6 +26,17 @@ mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
 
     # what type of object to return
     if (endomorphic) {
+        if (aggregate != "none") {
+            dna <- getDNA(object, aggregate = TRUE)
+            rna <- getRNA(object, aggregate = TRUE)
+            object <- object[!duplicated(rowData(object)$eid),]
+            rownames(object) <- rowData(object)$eid
+            rowData(object)$barcode <- NULL
+            assay(object, "DNA") <- dna[rowData(object)$eid,]
+            assay(object, "RNA") <- rna[rowData(object)$eid,]
+            if (ncol(rowData(object)) > 1)
+                message("rowData columns preserved, using first occurence of each eid")
+        }
         attr(object, "MArrayLM") <- fit
         tt <- topTable(fit, ..., number=nrow(fit), sort.by="none")
         stopifnot(all(rownames(tt) %in% rowData(object)$eid))

--- a/R/fit.R
+++ b/R/fit.R
@@ -1,5 +1,8 @@
-mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
-                   normalize = TRUE, block = NULL,
+mpralm <- function(object, design,
+                   aggregate = c("mean", "sum", "none"),
+                   normalize = TRUE,
+                   normalizeSize = 10e6,
+                   block = NULL,
                    model_type = c("indep_groups", "corr_groups"),
                    plot = TRUE,
                    endomorphic = FALSE,
@@ -14,28 +17,57 @@ mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
     
     if (model_type=="indep_groups") {
         fit <- .fit_standard(object = object, design = design,
-                             aggregate = aggregate, normalize = normalize,
+                             aggregate = aggregate,
+                             normalize = normalize,
+                             normalizeSize = normalizeSize,
                              plot = plot, ...)
     } else if (model_type=="corr_groups") {
         if (is.null(block)) {
             stop("'block' must be supplied for the corr_groups model type")
         }
-        fit <- .fit_corr(object = object, design = design, aggregate = aggregate,
-                         normalize = normalize, block = block, plot = plot, ...)
+        fit <- .fit_corr(object = object, design = design,
+                         aggregate = aggregate,
+                         normalize = normalize,
+                         normalizeSize = normalizeSize,
+                         block = block,
+                         plot = plot, ...)
     }
 
-    # what type of object to return
-    if (endomorphic) {
+    # the default, return the MArrayLM object
+    if (!endomorphic) {
+        return(fit)
+    } else if (endomorphic) {
+
+        # endomorphic means we send back the original object, 'MPRASet'
+        # with information attached in relevant slots
+        
+        if (aggregate == "none" & normalize) {
+            # just need to provide the scaled counts
+            scaled_object <- normalize_counts(object, normalizeSize = normalizeSize)
+            assay(object, "scaledDNA") <- assay(scaled_object, "DNA")
+            assay(object, "scaledRNA") <- assay(scaled_object, "RNA")
+        }
         if (aggregate != "none") {
+            # need to do the aggregation step first
             dna <- getDNA(object, aggregate = TRUE)
             rna <- getRNA(object, aggregate = TRUE)
+            if (normalize) {
+                # and get the scaled counts
+                object <- normalize_counts(object, normalizeSize = normalizeSize)
+                scaled_dna <- getDNA(object, aggregate = TRUE)
+                scaled_rna <- getRNA(object, aggregate = TRUE)
+            }
             object <- object[!duplicated(rowData(object)$eid),]
             rownames(object) <- rowData(object)$eid
             rowData(object)$barcode <- NULL
             assay(object, "DNA") <- dna[rowData(object)$eid,]
             assay(object, "RNA") <- rna[rowData(object)$eid,]
+            if (normalize) {
+                assay(object, "scaledDNA") <- scaled_dna[rowData(object)$eid,]
+                assay(object, "scaledRNA") <- scaled_rna[rowData(object)$eid,]
+            }
             if (ncol(rowData(object)) > 1)
-                message("rowData columns preserved, using first occurence of each eid")
+                message("rowData columns preserved in aggregation using first occurence of eid")
         }
         attr(object, "MArrayLM") <- fit
         tt <- topTable(fit, ..., number=nrow(fit), sort.by="none")
@@ -43,8 +75,6 @@ mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
         tt <- tt[rowData(object)$eid, ]
         rowData(object) <- cbind(rowData(object), tt)
         return(object)
-    } else {
-        return(fit)
     }
 }
 
@@ -102,7 +132,7 @@ compute_logratio <- function(object, aggregate = c("mean", "sum", "none")) {
     return(logr)
 }
 
-normalize_counts <- function(object, block = NULL) {
+normalize_counts <- function(object, normalizeSize = 10e6, block = NULL) {
     .is_mpra_or_stop(object)
 
     ## Perform total count normalization
@@ -120,8 +150,8 @@ normalize_counts <- function(object, block = NULL) {
                                sum, na.rm = TRUE)
         libsizes_rna <- libsizes_rna[block]
     }
-    dna_norm <- round(sweep(dna, 2, libsizes_dna, FUN = "/")*10e6)
-    rna_norm <- round(sweep(rna, 2, libsizes_rna, FUN = "/")*10e6)
+    dna_norm <- round(sweep(dna, 2, libsizes_dna, FUN = "/") * normalizeSize)
+    rna_norm <- round(sweep(rna, 2, libsizes_rna, FUN = "/") * normalizeSize)
     
     assay(object, "DNA") <- dna_norm
     assay(object, "RNA") <- rna_norm
@@ -130,7 +160,8 @@ normalize_counts <- function(object, block = NULL) {
 }
 
 .fit_standard <- function(object, design, aggregate = c("mean", "sum", "none"),
-                          normalize = TRUE, return_elist = FALSE,
+                          normalize = TRUE, normalizeSize = normalizeSize,
+                          return_elist = FALSE,
                           return_weights = FALSE, plot = TRUE, span = 0.4, ...) {
     .is_mpra_or_stop(object)
     if (nrow(design) != ncol(object)) {
@@ -140,7 +171,7 @@ normalize_counts <- function(object, block = NULL) {
     aggregate <- match.arg(aggregate)
 
     if (normalize) {
-        object <- normalize_counts(object)
+        object <- normalize_counts(object, normalizeSize = normalizeSize)
     }
     logr <- compute_logratio(object, aggregate = aggregate)
     log_dna <- log2(getDNA(object, aggregate = TRUE) + 1)
@@ -163,8 +194,9 @@ normalize_counts <- function(object, block = NULL) {
 }
 
 .fit_corr <- function(object, design, aggregate = c("mean", "sum", "none"),
-                     normalize = TRUE, block = NULL, return_elist = FALSE,
-                     return_weights = FALSE, plot = TRUE, span = 0.4, ...) {
+                      normalize = TRUE, normalizeSize = normalizeSize,
+                      block = NULL, return_elist = FALSE,
+                      return_weights = FALSE, plot = TRUE, span = 0.4, ...) {
     .is_mpra_or_stop(object)
     if (nrow(design) != ncol(object)) {
         stop("Rows of design must correspond to the columns of object")
@@ -173,7 +205,7 @@ normalize_counts <- function(object, block = NULL) {
     aggregate <- match.arg(aggregate)
 
     if (normalize) {
-        object <- normalize_counts(object, block)
+        object <- normalize_counts(object, normalizeSize = normalizeSize, block)
     }
     logr <- compute_logratio(object, aggregate = aggregate)
     log_dna <- log2(getDNA(object, aggregate = TRUE) + 1)

--- a/R/fit.R
+++ b/R/fit.R
@@ -1,7 +1,9 @@
 mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
                    normalize = TRUE, block = NULL,
                    model_type = c("indep_groups", "corr_groups"),
-                   plot = TRUE, ...) {
+                   plot = TRUE,
+                   endomorphic = FALSE,
+                   ...) {
     .is_mpra_or_stop(object)
     if (nrow(design) != ncol(object)) {
         stop("Rows of design must correspond to the columns of object")
@@ -21,7 +23,17 @@ mpralm <- function(object, design, aggregate = c("mean", "sum", "none"),
         fit <- .fit_corr(object = object, design = design, aggregate = aggregate,
                          normalize = normalize, block = block, plot = plot, ...)
     }
-    return(fit)
+
+    # what type of object to return
+    if (endomorphic) {
+      attr(object, "MArrayLM") <- fit
+      tt <- topTable(fit, ..., number=nrow(fit), sort.by="none")
+      stopifnot(all.equal(rowData(object)$eid, rownames(tt)))
+      rowData(object) <- cbind(rowData(object), tt)
+      return(object)
+    } else {
+      return(fit)
+    }
 }
 
 get_precision_weights <- function(logr, design, log_dna, span = 0.4,

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@
 
 .show.barcodePresence <- function(object) {
     if ("barcode" %in% names(rowData(object)))
-        cat("Barcodes present")
+        message("(barcodes present)")
     else
-        cat("No barcodes present")
+        message("(no barcodes present)")
 }

--- a/inst/scripts/endomorphic.R
+++ b/inst/scripts/endomorphic.R
@@ -1,0 +1,31 @@
+library(mpra)
+data(mpraSetExample)
+m <- mpraSetExample
+
+colData(m)$condition <- factor(c("MT","MT","MT","WT","WT","WT"),
+                                            levels=c("WT","MT"))
+random_ids <- apply(
+  matrix(sample(letters, 10 * length(unique(rowData(m)$eid)),
+                replace = TRUE), ncol=10),
+  1, paste0, collapse="")
+
+rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
+rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+rowData(m)$score <- rnorm(nrow(m))
+rowData(m)
+
+design <- model.matrix(~condition, colData(m))
+
+fit <- mpralm(
+  object = m,
+  design = design,
+  aggregate = "sum",
+  normalize = TRUE,
+  model_type = "indep_groups",
+  plot = FALSE
+)
+
+class(fit)
+
+tab <- topTable(fit, coef = 2, number = Inf)
+head(tab)

--- a/inst/scripts/endomorphic.R
+++ b/inst/scripts/endomorphic.R
@@ -10,8 +10,7 @@ random_ids <- apply(
                   replace = TRUE), ncol=10),
     1, paste0, collapse="")
 
-#rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
-#rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+rowData(m)$old_eid <- rowData(m)$eid
 rowData(m)$eid <- paste0("e",seq_len(nrow(m)))
 rowData(m)$score <- rnorm(nrow(m))
 rowData(m)
@@ -27,3 +26,21 @@ class(fit) # MPRASet object
 
 tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
 head(tab)
+
+all.equal(tab[mcols(fit)$eid,"logFC"], mcols(fit)$logFC)
+
+# now try it with aggregation
+rowData(m)$eid <- rowData(m)$old_eid
+rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
+rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+
+fit <- mpralm(object = m, design = design, aggregate = "sum",
+              normalize = TRUE, model_type = "indep_groups",
+              plot = FALSE, endomorphic = TRUE, coef = 2)
+
+class(fit) # MPRASet object
+
+tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
+head(tab)
+
+all.equal(tab[mcols(fit)$eid,"logFC"], mcols(fit)$logFC)

--- a/inst/scripts/endomorphic.R
+++ b/inst/scripts/endomorphic.R
@@ -2,15 +2,10 @@
 devtools::load_all()
 data(mpraSetExample)
 m <- mpraSetExample[1:10000,] # for speed
-
 colData(m)$condition <- factor(c("MT","MT","MT","WT","WT","WT"),
                                levels=c("WT","MT"))
-random_ids <- apply(
-    matrix(sample(letters, 10 * length(unique(rowData(m)$eid)),
-                  replace = TRUE), ncol=10),
-    1, paste0, collapse="")
 
-rowData(m)$old_eid <- rowData(m)$eid
+# no aggregation
 rowData(m)$eid <- paste0("e",seq_len(nrow(m)))
 rowData(m)$score <- rnorm(nrow(m))
 rowData(m)
@@ -27,12 +22,14 @@ class(fit) # MPRASet object
 tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
 head(tab)
 
-all.equal(tab[mcols(fit)$eid,"logFC"], mcols(fit)$logFC)
+all.equal(tab[rowData(fit)$eid,"logFC"], rowData(fit)$logFC)
 
 # now try it with aggregation
-rowData(m)$eid <- rowData(m)$old_eid
-rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
-rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+data(mpraSetExample)
+m <- mpraSetExample[1:10000,] # for speed
+colData(m)$condition <- factor(c("MT","MT","MT","WT","WT","WT"),
+                               levels=c("WT","MT"))
+rowData(m)$eid <- paste("e",as.numeric(factor(rowData(m)$eid)))
 
 fit <- mpralm(object = m, design = design, aggregate = "sum",
               normalize = TRUE, model_type = "indep_groups",
@@ -43,4 +40,4 @@ class(fit) # MPRASet object
 tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
 head(tab)
 
-all.equal(tab[mcols(fit)$eid,"logFC"], mcols(fit)$logFC)
+all.equal(tab[rowData(fit)$eid,"logFC"], rowData(fit)$logFC)

--- a/inst/scripts/endomorphic.R
+++ b/inst/scripts/endomorphic.R
@@ -1,4 +1,5 @@
-library(mpra)
+# library(mpra)
+devtools::load_all()
 data(mpraSetExample)
 m <- mpraSetExample
 
@@ -22,10 +23,13 @@ fit <- mpralm(
   aggregate = "sum",
   normalize = TRUE,
   model_type = "indep_groups",
-  plot = FALSE
+  plot = FALSE,
+  endomorphic = TRUE,
+  coef = 2
 )
 
-class(fit)
+# previously, an MArrayLM object
+class(fit) # MPRASet object
 
-tab <- topTable(fit, coef = 2, number = Inf)
+tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
 head(tab)

--- a/inst/scripts/endomorphic.R
+++ b/inst/scripts/endomorphic.R
@@ -1,32 +1,26 @@
 # library(mpra)
 devtools::load_all()
 data(mpraSetExample)
-m <- mpraSetExample
+m <- mpraSetExample[1:10000,] # for speed
 
 colData(m)$condition <- factor(c("MT","MT","MT","WT","WT","WT"),
-                                            levels=c("WT","MT"))
+                               levels=c("WT","MT"))
 random_ids <- apply(
-  matrix(sample(letters, 10 * length(unique(rowData(m)$eid)),
-                replace = TRUE), ncol=10),
-  1, paste0, collapse="")
+    matrix(sample(letters, 10 * length(unique(rowData(m)$eid)),
+                  replace = TRUE), ncol=10),
+    1, paste0, collapse="")
 
-rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
-rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+#rowData(m)$eid <- as.numeric(factor(rowData(m)$eid))
+#rowData(m)$eid <- random_ids[ rowData(m)$eid ]
+rowData(m)$eid <- paste0("e",seq_len(nrow(m)))
 rowData(m)$score <- rnorm(nrow(m))
 rowData(m)
 
 design <- model.matrix(~condition, colData(m))
 
-fit <- mpralm(
-  object = m,
-  design = design,
-  aggregate = "sum",
-  normalize = TRUE,
-  model_type = "indep_groups",
-  plot = FALSE,
-  endomorphic = TRUE,
-  coef = 2
-)
+fit <- mpralm(object = m, design = design, aggregate = "none",
+              normalize = TRUE, model_type = "indep_groups",
+              plot = FALSE, endomorphic = TRUE, coef = 2)
 
 # previously, an MArrayLM object
 class(fit) # MPRASet object

--- a/inst/unitTests/test_endomorphic.R
+++ b/inst/unitTests/test_endomorphic.R
@@ -1,0 +1,14 @@
+test_endo <- function() {
+    data(mpraSetExample)
+    m <- mpraSetExample[1:10000,]
+    colData(m)$condition <- factor(c("MT","MT","MT","WT","WT","WT"),
+                                   levels=c("WT","MT"))
+    rowData(m)$eid <- paste("e",as.numeric(factor(rowData(m)$eid)))
+    design <- model.matrix(~condition, colData(m))
+    fit <- mpralm(object = m, design = design, aggregate = "sum",
+                  normalize = TRUE, model_type = "indep_groups",
+                  plot = FALSE, endomorphic = TRUE, coef = 2)
+    checkTrue(is(fit, "MPRASet"))
+    tab <- topTable(attr(fit, "MArrayLM"), coef = 2, number = Inf)
+    checkEquals(tab[rowData(fit)$eid,"logFC"], rowData(fit)$logFC)
+}

--- a/man/mpra-package.Rd
+++ b/man/mpra-package.Rd
@@ -33,7 +33,7 @@ Maintainer: \packageMaintainer{mpra}
   \emph{Voom: Precision Weights Unlock Linear Model Analysis Tools for RNA-Seq Read Counts}. 
   Genome Biology 2014, 15:R29. \doi{10.1186/gb-2014-15-2-r29}.
 
-  Smyth, Gordon K., Jo\"{e}lle Michaud, and Hamish S. Scott. 
+  Smyth, Gordon K., Joelle Michaud, and Hamish S. Scott. 
   \emph{Use of within-Array Replicate Spots for Assessing Differential
     Expression in Microarray Experiments.} 
   Bioinformatics 2005, 21 (9): 2067-75. \doi{10.1093/bioinformatics/bti270}.

--- a/man/mpralm.Rd
+++ b/man/mpralm.Rd
@@ -7,7 +7,7 @@ Fits weighted linear models to test for differential activity in MPRA data.
 \usage{
 mpralm(object, design, aggregate = c("mean", "sum", "none"), normalize = TRUE,
        block = NULL, model_type = c("indep_groups", "corr_groups"),
-       plot = TRUE, ...)
+       plot = TRUE, endomorphic = FALSE, ...)
 }
 \arguments{
   \item{object}{An object of class \code{MPRASet}.}
@@ -28,6 +28,8 @@ mpralm(object, design, aggregate = c("mean", "sum", "none"), normalize = TRUE,
     (\code{"indep_groups"}) or a paired mixed-model fit
     ((\code{"corr_groups"})) should be used.}
   \item{plot}{If \code{TRUE}, plot the mean-variance relationship.}
+  \item{endomorphic}{If \code{TRUE}, return the same class as the input,
+    i.e. an object of class \code{MPRASet}.}
   \item{\dots}{Further arguments to be passed to \code{lmFit} for
     obtaining residual standard deviations used in estimating the
     mean-variance relationship.} 
@@ -39,7 +41,12 @@ estimate the intra-replicate correlation of log-ratio values.
 }
 \value{
 An object of class \code{MArrayLM} resulting from the \code{eBayes}
-function. 
+function.
+
+If \code{endomorphic = TRUE}, then an \code{MPRASet} is returned,
+with the output of \code{topTable} added to the \code{rowData},
+and the \code{MArrayLM} results added as an attribute
+\code{"MArrayLM"}.
 }
 \references{
   Myint, Leslie, Dimitrios G. Avramopoulos, Loyal A. Goff, and Kasper

--- a/man/mpralm.Rd
+++ b/man/mpralm.Rd
@@ -5,7 +5,8 @@
 Fits weighted linear models to test for differential activity in MPRA data.
 }
 \usage{
-mpralm(object, design, aggregate = c("mean", "sum", "none"), normalize = TRUE,
+mpralm(object, design, aggregate = c("mean", "sum", "none"),
+       normalize = TRUE, normalizeSize = 10e6,
        block = NULL, model_type = c("indep_groups", "corr_groups"),
        plot = TRUE, endomorphic = FALSE, ...)
 }
@@ -21,6 +22,8 @@ mpralm(object, design, aggregate = c("mean", "sum", "none"), normalize = TRUE,
     no aggregation (counts have already been summarized over barcodes).}
   \item{normalize}{If \code{TRUE}, perform total count normalization
     before model fitting.}
+  \item{normalizeSize}{If normalizing, the target library size (default
+    is 10e6).}
   \item{block}{A vector giving the sample designations of the columns of
     \code{object}. The default, \code{NULL}, indicates that all columns
     are separate samples.} 
@@ -59,7 +62,7 @@ and the \code{MArrayLM} results added as an attribute
   \emph{Voom: Precision Weights Unlock Linear Model Analysis Tools for RNA-Seq Read Counts}. 
   Genome Biology 2014, 15:R29. \doi{10.1186/gb-2014-15-2-r29}.
 
-  Smyth, Gordon K., Jo\"{e}lle Michaud, and Hamish S. Scott. 
+  Smyth, Gordon K., Joelle Michaud, and Hamish S. Scott. 
   \emph{Use of within-Array Replicate Spots for Assessing Differential
     Expression in Microarray Experiments.} 
   Bioinformatics 2005, 21 (9): 2067-75. \doi{10.1093/bioinformatics/bti270}.

--- a/man/normalize_counts.Rd
+++ b/man/normalize_counts.Rd
@@ -5,10 +5,12 @@
 Total count normalization of DNA and RNA counts.
 }
 \usage{
-normalize_counts(object, block = NULL)
+normalize_counts(object, normalizeSize = 10e6, block = NULL)
 }
 \arguments{
   \item{object}{An object of class \code{MPRASet}.}
+  \item{normalizeSize}{If normalizing, the target library size (default
+    is 10e6).}
   \item{block}{A vector giving the sample designations of the columns of
     \code{object}. The default, \code{NULL}, indicates that all columns
     are separate samples.} 

--- a/vignettes/mpra.Rmd
+++ b/vignettes/mpra.Rmd
@@ -216,6 +216,51 @@ toptab_allele <- topTable(mpralm_allele_fit, coef = 2, number = Inf)
 head(toptab_allele)
 ```
 
+## Returning an MPRASet
+
+The last section notes an option `endomorphic = TRUE` that changes the
+type of object returned by `mpralm` from an *MArrayLM* object to the
+original object, an *MPRASet* with the statistical results attached as
+`rowData` to the object. "Endomorphic" refers to the fact that the
+same type of object that is passed into the function is returned, but
+with additional information added.
+
+We can demonstrate with the example from above: 
+
+```{r}
+design <- data.frame(intcpt = 1,
+                     episomal = grepl("MT", colnames(mpraSetExample)))
+efit <- mpralm(object = mpraSetExample,
+               design = design,
+               aggregate = "sum",
+               normalize = TRUE,
+               model_type = "indep_groups",
+               plot = FALSE,
+               endomorphic = TRUE, coef = 2)
+# for ease of printing, because 'eid' are long here
+rownames(efit) <- paste0("elem_", seq_len(nrow(efit)))
+rowData(efit)
+```
+
+The `coef = 2` is passed to `topTable` which is run within `mpralm`.
+This option also returns `scaledDNA` and `scaledRNA` that were used to
+compute log ratios within `mpralm`. This can facilitate plotting
+statistics alongside original or scaled count data. 
+
+Just to demonstrate that the scaled counts were in fact the ones used
+for statistics, we can compute the raw LFC and compare to the LFC
+computed by *limma-voom* using precision weights.
+
+```{r}
+sdna <- assay(efit, "scaledDNA")
+srna <- assay(efit, "scaledRNA")
+mt <- rowMeans(log2(srna[,1:3] + 1) - log2(sdna[,1:3] + 1))
+wt <- rowMeans(log2(srna[,4:6] + 1) - log2(sdna[,4:6] + 1))
+raw_lfc <- mt - wt
+# very similar, precision weights modify LFC from limma a bit
+lm(raw_lfc ~ rowData(efit)$logFC)
+```
+
 # Session Info
 
 ```{r sessionInfo, results='asis', echo=FALSE}
@@ -223,5 +268,3 @@ sessionInfo()
 ```
 
 # References
-
-


### PR DESCRIPTION
I wanted to submit a preliminary PR to start the conversation, before I add things like unit tests and documentation in the vignette.

The idea here is to return the `MPRAset`, with results from `topTable` added as columns to `rowData`. The `MArrayLM` object is also added to the attributes of the object (similar to other tricks that have been used to tack things onto S4 objects).

There is a little trick when aggregation is in play, and here I've done a quick solution where new rowData is created by removing `barcodes` column and taking the first appearance of `eid` for the necessary row reduction.

I haven't done a ton of testing, I can do this next, but wanted to clear the general gist of the changes with your first.
